### PR TITLE
Bump alpine from 3.12.0 to 3.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0 AS base_image
+FROM alpine:3.12.1 AS base_image
 
 FROM base_image AS build
 


### PR DESCRIPTION
Bumps alpine from 3.12.0 to 3.12.1.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>